### PR TITLE
ci: explicitly enable `main` for semantic release

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,20 @@
     "husky": "^7.0.0"
   },
   "release": {
+    "branches": [
+      "+([0-9])?(.{+([0-9]),x}).x",
+      "master",
+      "main",
+      "next",
+      "next-major",
+      {
+        "name": "beta",
+        "prerelease": true
+      }, {
+        "name": "alpha",
+        "prerelease": true
+      }
+    ],
     "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",


### PR DESCRIPTION
Make sure semantic-release will run on this repo since the default branch is `main`

semantic-release does not yet support `main` as a default branch name.
see https://github.com/semantic-release/semantic-release/issues/1581