### PR TITLE
ci: disable husky when ci is running

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,7 @@
 #!/bin/sh
+# Disable Husky hooks on CI environments
+[ -n "$CI" ] && exit 0
+
 . "$(dirname "$0")/_/husky.sh"
 
 npx --no-install commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,7 @@
 #!/bin/sh
+# Disable Husky hooks on CI environments
+[ -n "$CI" ] && exit 0
+
 . "$(dirname "$0")/_/husky.sh"
 
 npm test

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,7 @@
 #!/bin/sh
+# Disable Husky hooks on CI environments
+[ -n "$CI" ] && exit 0
+
 . "$(dirname "$0")/_/husky.sh"
 
 npm test


### PR DESCRIPTION
husky hooks, specifically linting, prevent merging and cleanup
of changelog from semantic release